### PR TITLE
deb: extra debuild args in build_cfg.json and compilers from CC and CXX

### DIFF
--- a/.github/workflows/package-silkit.yml
+++ b/.github/workflows/package-silkit.yml
@@ -88,7 +88,10 @@ jobs:
                   "work_dir": "${{ env.PKG_WORKDIR }}",
                   "keep_temp": true,
                   "output_dir": "${{ env.PKG_OUTDIR }}",
-                  "platform": "Ubuntu-20.04"
+                  "platform": "Ubuntu-20.04",
+                  "debuild": {
+                      "args": ["-d", "--prepend-path=/opt/vector/bin"],
+                  }
               }
 
         run: |

--- a/scripts/silkit_deb.py
+++ b/scripts/silkit_deb.py
@@ -2,6 +2,7 @@ import logging
 import shutil
 import subprocess
 import re
+import os
 
 from pathlib import Path
 
@@ -129,7 +130,8 @@ class SilKitDEB(SilKitPKG):
                 else ""
             )
 
-            debuild_flags = build_flags.add_debuild_flags.split(" ")
+            debuild_flags = [*build_flags.add_debuild_flags, *self.build_info.debuild.args]
+
             logger.debug(f"Additional debuild flags: {debuild_flags}")
             debuild_cmd = (
                 ["debuild"]
@@ -158,28 +160,33 @@ class SilKitDEB(SilKitPKG):
 
     @staticmethod
     def __get_debian_build_flags(ubuntu_version: str) -> BuildFlags:
-
         logger.info(f"Building for platform: {ubuntu_version}")
+
+        def env_or(name, default):
+            return os.environ.get(name, default)
+
         if ubuntu_version == "20.04":
             return BuildFlags(
-                add_platform_flags="",
-                add_debuild_flags="-d --prepend-path=/opt/vector/bin",
-                c_compiler="clang-10",
-                cxx_compiler="clang++-10",
+                add_platform_flags="-gdwarf-4",
+                add_debuild_flags=[],
+                c_compiler=env_or("CC", "clang"),
+                cxx_compiler=env_or("CXX", "clang++"),
             )
+
         if ubuntu_version == "22.04":
             return BuildFlags(
                 add_platform_flags="-gdwarf-4",
-                add_debuild_flags="",
-                c_compiler="clang",
-                cxx_compiler="clang++",
+                add_debuild_flags=[],
+                c_compiler=env_or("CC", "clang"),
+                cxx_compiler=env_or("CXX", "clang++"),
             )
+
         if ubuntu_version == "24.04":
             return BuildFlags(
-                add_platform_flags="",
-                add_debuild_flags="",
-                c_compiler="clang",
-                cxx_compiler="clang++",
+                add_platform_flags="-gdwarf-4",
+                add_debuild_flags=[],
+                c_compiler=env_or("CC", "clang"),
+                cxx_compiler=env_or("CXX", "clang++"),
             )
 
         return None

--- a/scripts/silkit_linux_packaging.py
+++ b/scripts/silkit_linux_packaging.py
@@ -11,7 +11,7 @@ from argparse import ArgumentParser
 from dataclasses import dataclass
 from pathlib import Path
 
-from silkit_pkg_utils import BuildInfo, SilKitVersion, SilKitInfo
+from silkit_pkg_utils import BuildInfo, SilKitVersion, SilKitInfo, DebuildInfo
 from silkit_pkg_utils import set_global_loglevel, get_global_loglevel, get_global_formatting
 from silkit_pkg_interface import SilKitPKG
 from silkit_deb import SilKitDEB
@@ -73,6 +73,10 @@ def generate_buildinfo(cfg) -> BuildInfo:
             patch=cfg["version"]["patch"],
             suffix=cfg["version"]["suffix"])
 
+    debuild_info = DebuildInfo(
+            args=cfg.get("debuild", {}).get("args", []),
+    )
+
     build_info = BuildInfo(
             silkit_pkg_path=Path(cfg["package_repo_path"]),
             silkit_info=silkit_info,
@@ -81,8 +85,10 @@ def generate_buildinfo(cfg) -> BuildInfo:
             work_dir=Path(cfg["work_dir"]),
             keep_temp=cfg["keep_temp"],
             output_dir=Path(cfg["output_dir"]),
-            platform=cfg["platform"]
+            platform=cfg["platform"],
+            debuild=debuild_info,
     )
+
     logger.debug(f"build_info: {build_info}")
     return build_info
 

--- a/scripts/silkit_pkg_utils.py
+++ b/scripts/silkit_pkg_utils.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 import subprocess
 import logging
@@ -33,6 +33,11 @@ class SilKitInfo:
 
 
 @dataclass
+class DebuildInfo:
+    args: list
+
+
+@dataclass
 class BuildInfo:
 
     silkit_pkg_path: Path
@@ -43,12 +48,13 @@ class BuildInfo:
     work_dir: Path
     keep_temp: bool
     output_dir: Path
+    debuild: DebuildInfo
 
 
 @dataclass
 class BuildFlags:
-    add_platform_flags: str
-    add_debuild_flags: str
+    add_platform_flags: list
+    add_debuild_flags: list
     c_compiler: str
     cxx_compiler: str
 


### PR DESCRIPTION
I would like to put the 'compatibility' flags into the `build_cfg.json` and not hardcode them in the `silkit_deb.py`. Do you think this 'fits' with the idea behind the scripts?