### PR TITLE
Fix debian service

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libsilkit (5.0.2~rc1-1ubuntu1) UNRELEASED; urgency=medium
+
+  * Do not enable the silkit-registry.service by default
+
+ -- Jan Kraemer <jan.kraemer@vector.com>  Wed, 24 Aug 2025 17:00:00 +0200
+
 libsilkit (5.0.1-1ubuntu1) UNRELEASED; urgency=medium
 
   * Fix building SIL Kit from source

--- a/debian/rules
+++ b/debian/rules
@@ -14,4 +14,4 @@ override_dh_auto_test:
 	ctest --output-on-failure -R '^(I|T)' --test-dir _build
 
 override_dh_installsystemd:
-	dh_installsystemd  -psilkit-utils --name silkit-registry silkit-registry.service --no-start
+	dh_installsystemd  -psilkit-utils --name silkit-registry silkit-registry.service --no-start --no-enable

--- a/rpm/libsilkit5.spec
+++ b/rpm/libsilkit5.spec
@@ -1,7 +1,7 @@
 %define version_major 5
 %define version_minor 0
-%define version_patch 1
-%define version_suffix %{nil}
+%define version_patch 2
+%define version_suffix rc1
 
 
 %if "%{version_suffix}" == ""
@@ -89,6 +89,9 @@ install -p -D -m 0644 %{SOURCE1} %{buildroot}/%{_unitdir}/
 %{_unitdir}/sil-kit-registry.service
 
 %changelog
+
+* Wed Sep 24 2025 Jan Kraemer <jan.kraemer@vector.com> - 5.0.2~rc1
+- New Pre-Release
 
 * Wed Aug 06 2025 Jan Kraemer <jan.kraemer@vector.com> - 5.0.1
 - Fix building SIL Kit from source


### PR DESCRIPTION
The Debian Service was auto enabled after install. We do not want that so we install it with --no-enable!