### PR TITLE
ci: Update Github actions

### DIFF
--- a/.github/workflows/package-silkit.yml
+++ b/.github/workflows/package-silkit.yml
@@ -45,7 +45,7 @@ jobs:
       silkit_suffix: ${{ steps.get_version.outputs.silkit_suffix }}
     steps:
       - name: Checkout (sil-kit-pkg)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: sil-kit-pkg
 
@@ -82,12 +82,12 @@ jobs:
     steps:
 
       - name: Checkout (sil-kit-pkg)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: sil-kit-pkg
 
       - name: Checkout (sil-kit)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.silkit_source_repo }}
           submodules: recursive
@@ -154,7 +154,7 @@ jobs:
 
       - name: Artifact
         id: artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
@@ -178,12 +178,12 @@ jobs:
     steps:
 
       - name: Checkout (sil-kit-pkg)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: sil-kit-pkg
 
       - name: Checkout (sil-kit)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.silkit_source_repo }}
           submodules: recursive
@@ -243,7 +243,7 @@ jobs:
 
       - name: Artifact
         id: artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
@@ -260,12 +260,12 @@ jobs:
     steps:
 
       - name: Checkout (sil-kit-pkg)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: sil-kit-pkg
 
       - name: Checkout (sil-kit)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.silkit_source_repo }}
           submodules: recursive
@@ -340,7 +340,7 @@ jobs:
 
       - name: Artifact
         id: artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
@@ -362,7 +362,7 @@ jobs:
     steps:
 
       - name: download_artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Prepare artifact
         run: |
@@ -385,7 +385,7 @@ jobs:
           esac
 
       - name: Create git tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             try {


### PR DESCRIPTION
Due to the Github deprecation of Node20 we need to update all Github actions. See:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/