### PR TITLE
Fix CI for v5.0.6

### DIFF
--- a/.github/workflows/package-silkit.yml
+++ b/.github/workflows/package-silkit.yml
@@ -275,7 +275,7 @@ jobs:
 
       - name: Install debhelper
         run: |
-
+          sudo apt update -y &&\
           sudo apt-get install -y \
               debhelper \
               dpkg-dev \

--- a/.github/workflows/package-silkit.yml
+++ b/.github/workflows/package-silkit.yml
@@ -45,7 +45,7 @@ jobs:
       silkit_suffix: ${{ steps.get_version.outputs.silkit_suffix }}
     steps:
       - name: Checkout (sil-kit-pkg)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: sil-kit-pkg
 
@@ -82,12 +82,12 @@ jobs:
     steps:
 
       - name: Checkout (sil-kit-pkg)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: sil-kit-pkg
 
       - name: Checkout (sil-kit)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.silkit_source_repo }}
           submodules: recursive
@@ -154,7 +154,7 @@ jobs:
 
       - name: Artifact
         id: artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
@@ -178,12 +178,12 @@ jobs:
     steps:
 
       - name: Checkout (sil-kit-pkg)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: sil-kit-pkg
 
       - name: Checkout (sil-kit)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.silkit_source_repo }}
           submodules: recursive
@@ -243,7 +243,7 @@ jobs:
 
       - name: Artifact
         id: artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
@@ -260,12 +260,12 @@ jobs:
     steps:
 
       - name: Checkout (sil-kit-pkg)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: sil-kit-pkg
 
       - name: Checkout (sil-kit)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.silkit_source_repo }}
           submodules: recursive
@@ -340,7 +340,7 @@ jobs:
 
       - name: Artifact
         id: artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |


### PR DESCRIPTION
Update actions to the newest version

Fix ARM64 build by doing a apt update before installing debhelper